### PR TITLE
Fix path simple-page css broken on Jenkins 2.346.x

### DIFF
--- a/src/main/resources/templates/mosaml_login_page_template.html
+++ b/src/main/resources/templates/mosaml_login_page_template.html
@@ -4,9 +4,9 @@
     <meta name="ROBOTS" content="NOFOLLOW" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <link rel="stylesheet" href="/static/b7cbcca1/css/simple-page.css" type="text/css">
-    <link rel="stylesheet" href="/static/b7cbcca1/css/simple-page.theme.css" type="text/css">
-    <link rel="stylesheet" href="/static/b7cbcca1/css/simple-page-forms.css" type="text/css">
+    <link rel="stylesheet" href="/static/b7cbcca1/jsbundles/simple-page.css" type="text/css">
+    <link rel="stylesheet" href="/static/b7cbcca1/jsbundles/simple-page.theme.css" type="text/css">
+    <link rel="stylesheet" href="/static/b7cbcca1/jsbundles/simple-page-forms.css" type="text/css">
 </head>
 
 <body>


### PR DESCRIPTION
from version 2.346.x simple-page-xxx.css is under jsbundles/ e no mor on css/

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
